### PR TITLE
Fix obstructed scrollbar in sidebar main section

### DIFF
--- a/src/menu-slider/ia-menu-slider.ts
+++ b/src/menu-slider/ia-menu-slider.ts
@@ -150,9 +150,9 @@ export class IaMenuSlider extends LitElement {
             @menuTypeSelected=${this.setSelectedMenu}
           >
             ${this.renderMenuHeader}
-            <section>
+            <main>
               <div class="selected-menu">${this.selectedMenuComponent}</div>
-            </section>
+            </main>
           </div>
         </div>
       </div>

--- a/src/menu-slider/ia-menu-slider.ts
+++ b/src/menu-slider/ia-menu-slider.ts
@@ -150,9 +150,9 @@ export class IaMenuSlider extends LitElement {
             @menuTypeSelected=${this.setSelectedMenu}
           >
             ${this.renderMenuHeader}
-            <main>
+            <section>
               <div class="selected-menu">${this.selectedMenuComponent}</div>
-            </main>
+            </section>
           </div>
         </div>
       </div>

--- a/src/menu-slider/styles/menu-slider.ts
+++ b/src/menu-slider/styles/menu-slider.ts
@@ -112,7 +112,7 @@ export default css`
     margin-bottom: 0.2rem;
   }
 
-  .content > main {
+  .content > section {
     overflow: auto;
     overscroll-behavior: contain;
   }

--- a/src/menu-slider/styles/menu-slider.ts
+++ b/src/menu-slider/styles/menu-slider.ts
@@ -94,6 +94,8 @@ export default css`
     border-right: 0.2rem solid;
     border-color: var(--subpanelRightBorderColor);
     padding: 0.5rem 0 0 0.5rem;
+    display: flex;
+    flex-direction: column;
   }
 
   .open {
@@ -110,21 +112,8 @@ export default css`
     margin-bottom: 0.2rem;
   }
 
-  .content section {
-    height: 100%;
-    position: relative;
-    width: 100%;
-  }
-
-  .content .selected-menu {
+  .content > main {
     overflow: auto;
-    height: inherit;
-    position: relative;
-  }
-
-  .content .selected-menu > * {
-    display: block;
-    padding-bottom: 3rem;
-    position: relative;
+    overscroll-behavior: contain;
   }
 `;


### PR DESCRIPTION
The scroll bar is obstructed because the main section is too big for the container! The main section is `100%` but that doesn't take into account the header, so it ends up being too large. Besides the minor visual nuisance, this caused issues when using `scrollIntoView`, because it would scroll the weird inbetween section thing here.

| Before | After |
| -- | -- |
| ![image](https://github.com/internetarchive/iaux-menu-slider/assets/6251786/f4b4b4b8-2a25-4641-a0d0-65d1d190932e) | ![image](https://github.com/internetarchive/iaux-menu-slider/assets/6251786/2a8afc6e-d6e8-480a-b878-72279f9c65a6) |

To test:

1. Clone both `bookreader` (latest master) and this repo.
2. In *this repo* run `npm i && npm link` (you have to use npm since BR uses npm)
3. In *bookreader* run `npm link @internetarchive/ia-item-navigator`
4. In *this repo* run `npm start`
5. In *bookreader* run `npm run serve-dev`

You can then go to http://127.0.0.1:8080/BookReaderDemo/demo-internetarchive.html?ocaid=adventureofsherl0000unse#page/n11/mode/2up/search/suspicion and observer the search panel !