### PR TITLE
Applied fix for FF and other browsers to auto-scroll to active volume

### DIFF
--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -354,7 +354,7 @@ export class AppRoot extends LitElement {
         .fileListRaw=${fileList}
       ></iaux-in-sort-files-button>`,
       component: html`<iaux-in-viewable-files-panel
-        .subPrefix=${'Master Book of American Folk Song Vol. 5'}
+        .subPrefix=${'onestrandriverpdf'}
         .fileList=${filesNewArr}
       ></iaux-in-viewable-files-panel> `,
     };

--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -354,7 +354,7 @@ export class AppRoot extends LitElement {
         .fileListRaw=${fileList}
       ></iaux-in-sort-files-button>`,
       component: html`<iaux-in-viewable-files-panel
-        .subPrefix=${'onestrandriverpdf'}
+        .subPrefix=${'Master Book of American Folk Song Vol. 5'}
         .fileList=${filesNewArr}
       ></iaux-in-viewable-files-panel> `,
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-item-navigator",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Internet Archive's Item Navigator, visually explore an item's contents.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-item-navigator",
-  "version": "2.0.3",
+  "version": "2.1.1-alpha2",
   "description": "Internet Archive's Item Navigator, visually explore an item's contents.",
   "repository": {
     "type": "git",

--- a/src/menus/viewable-files.ts
+++ b/src/menus/viewable-files.ts
@@ -230,7 +230,7 @@ export class IauxViewableFiles extends LitElement {
         activeFile?.scrollIntoViewIfNeeded(true);
       } else {
         // `scrollIntoView` always auto-scroll to center of visible area
-        activeFile?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' })
+        activeFile?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
       }
     }, 350);
   }

--- a/src/menus/viewable-files.ts
+++ b/src/menus/viewable-files.ts
@@ -222,12 +222,16 @@ export class IauxViewableFiles extends LitElement {
     // allow for css animations to run before scrolling to active file
     setTimeout(() => {
       // scroll active file into view if needed
-      // note: `scrollIntoViewIfNeeded` handles auto-scroll gracefully for Chrome, Safari
-      // Firefox does not have this capability yet as it does not support `scrollIntoViewIfNeeded`
-      activeFile?.scrollIntoViewIfNeeded(true);
-
-      // Todo: support `scrollIntoView` or `parentContainer.crollTop = x` for FF & "IE 11"
-      // currently, the hard `position: absolutes` misaligns subpanel when `scrollIntoView` is applied :(
+      // note:
+      // - `scrollIntoViewIfNeeded` handles auto-scroll gracefully for Chrome, Safari
+      // - `scrollIntoView` handles auto-scroll for almost all the browsers. specifially FF.
+      if (activeFile?.scrollIntoViewIfNeeded) {
+        // `scrollIntoViewIfNeeded` auto-scroll only if element not is visible area 
+        activeFile?.scrollIntoViewIfNeeded(true);
+      } else {
+        // `scrollIntoView` always auto-scroll to center of visible area
+        activeFile?.scrollIntoView({ behavior: 'auto', block:   'center' });
+      }
     }, 350);
   }
 
@@ -269,6 +273,7 @@ export class IauxViewableFiles extends LitElement {
   }
 
   fileLi(item: ItemInfo): TemplateResult {
+    console.log(this.subPrefix)
     const activeClass = this.subPrefix === item.file_subprefix ? ' active' : '';
     const hrefUrl = this.fileUrl(item);
     const isPdf = (item.file_source ?? '').match(/^[^+]+\.pdf$/i);

--- a/src/menus/viewable-files.ts
+++ b/src/menus/viewable-files.ts
@@ -273,7 +273,6 @@ export class IauxViewableFiles extends LitElement {
   }
 
   fileLi(item: ItemInfo): TemplateResult {
-    console.log(this.subPrefix)
     const activeClass = this.subPrefix === item.file_subprefix ? ' active' : '';
     const hrefUrl = this.fileUrl(item);
     const isPdf = (item.file_source ?? '').match(/^[^+]+\.pdf$/i);

--- a/src/menus/viewable-files.ts
+++ b/src/menus/viewable-files.ts
@@ -230,7 +230,7 @@ export class IauxViewableFiles extends LitElement {
         activeFile?.scrollIntoViewIfNeeded(true);
       } else {
         // `scrollIntoView` always auto-scroll to center of visible area
-        activeFile?.scrollIntoView({ behavior: 'auto', block: 'center' });
+        activeFile?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' })
       }
     }, 350);
   }

--- a/src/menus/viewable-files.ts
+++ b/src/menus/viewable-files.ts
@@ -230,7 +230,11 @@ export class IauxViewableFiles extends LitElement {
         activeFile?.scrollIntoViewIfNeeded(true);
       } else {
         // `scrollIntoView` always auto-scroll to center of visible area
-        activeFile?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+        activeFile?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'nearest',
+          inline: 'nearest',
+        });
       }
     }, 350);
   }

--- a/src/menus/viewable-files.ts
+++ b/src/menus/viewable-files.ts
@@ -226,11 +226,11 @@ export class IauxViewableFiles extends LitElement {
       // - `scrollIntoViewIfNeeded` handles auto-scroll gracefully for Chrome, Safari
       // - `scrollIntoView` handles auto-scroll for almost all the browsers. specifially FF.
       if (activeFile?.scrollIntoViewIfNeeded) {
-        // `scrollIntoViewIfNeeded` auto-scroll only if element not is visible area 
+        // `scrollIntoViewIfNeeded` auto-scroll only if element not is visible area
         activeFile?.scrollIntoViewIfNeeded(true);
       } else {
         // `scrollIntoView` always auto-scroll to center of visible area
-        activeFile?.scrollIntoView({ behavior: 'auto', block:   'center' });
+        activeFile?.scrollIntoView({ behavior: 'auto', block: 'center' });
       }
     }, 350);
   }


### PR DESCRIPTION
https://webarchive.jira.com/browse/WEBDEV-6544

Bookreader shows subfiles panel in left side panel where Firefox is not auto scrolling to selected volume of book having subfiles