### PR TITLE
 Improve screenreader a11y of icons/menu navigation

### DIFF
--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -286,6 +286,7 @@ export class AppRoot extends LitElement {
           Exit
         </button>`,
         id: 'exit',
+        label: 'Exit',
       },
     ];
     this.menuContents = [

--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -13,6 +13,7 @@ import '../src/menus/share-panel';
 import {
   MenuShortcutInterface,
   MenuProviderInterface,
+  MenuDetailsInterface,
 } from '../src/interfaces/menu-interfaces';
 import { iauxShareIcon } from '../src/menus/share-panel';
 import { viewableFilesIcon } from '../src/menus/viewable-files';
@@ -149,7 +150,7 @@ export class AppRoot extends LitElement {
   sharedObserver = new SharedResizeObserver();
 
   @property({ type: Array, attribute: false })
-  menuContents: MenuProviderInterface[] = [];
+  menuContents: MenuDetailsInterface[] = [];
 
   @property({ type: Array, attribute: false })
   menuShortcuts: MenuShortcutInterface[] = [];
@@ -326,7 +327,7 @@ export class AppRoot extends LitElement {
   }
 
   drawMenus() {
-    const shareMenu = {
+    const shareMenu: MenuDetailsInterface = {
       icon: iauxShareIcon,
       label: 'Share this item',
       id: 'share',
@@ -338,7 +339,7 @@ export class AppRoot extends LitElement {
         .baseHost=${'archive.org'}
         .fileSubPrefix=${''}
       ></iaux-in-share-panel>`,
-    } as unknown as MenuProviderInterface;
+    };
 
     const filesNewArr = [...fileList];
     const viewableFilesMenu = {
@@ -370,7 +371,6 @@ export class AppRoot extends LitElement {
     await this.updateComplete;
     console.log('fileListSortedasyncd', { sortType, sortedFiles });
     this.drawMenus();
-    // debugger;
   }
 
   /** Views */

--- a/src/iaux-item-navigator.ts
+++ b/src/iaux-item-navigator.ts
@@ -35,6 +35,7 @@ import {
   MenuId,
 } from './interfaces/menu-interfaces';
 import './no-theater-available';
+import type { IaMenuSlider } from './menu-slider/ia-menu-slider';
 
 @customElement('iaux-item-navigator')
 export class ItemNavigator
@@ -83,6 +84,10 @@ export class ItemNavigator
   @query('slot[name="header"]') private headerSlot!: HTMLSlotElement;
 
   @query('slot[name="main"]') private mainSlot!: HTMLSlotElement;
+
+  @query('ia-menu-slider') private menuSlider!: IaMenuSlider;
+
+  @query('button.toggle-menu') private toggleMenuButton!: HTMLButtonElement;
 
   disconnectedCallback() {
     super.disconnectedCallback();
@@ -238,10 +243,7 @@ export class ItemNavigator
     if (this.menuOpened) {
       // Move focus to the <ia-menu-slider>
       this.updateComplete.then(() => {
-        const menuSlider = this.renderRoot.querySelector(
-          'ia-menu-slider',
-        ) as HTMLElement;
-        const closeButton = menuSlider?.shadowRoot?.querySelector(
+        const closeButton = this.menuSlider?.shadowRoot?.querySelector(
           'button.close',
         ) as HTMLElement;
         closeButton?.focus();
@@ -249,10 +251,7 @@ export class ItemNavigator
     } else {
       // Move focus back to the menu toggle button
       this.updateComplete.then(() => {
-        const toggleButton = this.renderRoot.querySelector(
-          'button.toggle-menu',
-        ) as HTMLElement;
-        toggleButton?.focus();
+        this.toggleMenuButton?.focus();
       });
     }
   }

--- a/src/iaux-item-navigator.ts
+++ b/src/iaux-item-navigator.ts
@@ -297,10 +297,7 @@ export class ItemNavigator
         title="Toggle theater side panels"
         aria-label="Toggle theater side panels"
       >
-        <ia-icon-ellipses
-          aria-hidden="true"
-          role="presentation"
-        ></ia-icon-ellipses>
+        <ia-icon-ellipses aria-hidden="true"></ia-icon-ellipses>
       </button>
     `;
   }

--- a/src/iaux-item-navigator.ts
+++ b/src/iaux-item-navigator.ts
@@ -238,14 +238,20 @@ export class ItemNavigator
     if (this.menuOpened) {
       // Move focus to the <ia-menu-slider>
       this.updateComplete.then(() => {
-        const menuSlider = this.renderRoot.querySelector('ia-menu-slider') as HTMLElement;
-        const closeButton = menuSlider?.shadowRoot?.querySelector('button.close') as HTMLElement;
+        const menuSlider = this.renderRoot.querySelector(
+          'ia-menu-slider',
+        ) as HTMLElement;
+        const closeButton = menuSlider?.shadowRoot?.querySelector(
+          'button.close',
+        ) as HTMLElement;
         closeButton?.focus();
       });
     } else {
       // Move focus back to the menu toggle button
       this.updateComplete.then(() => {
-        const toggleButton = this.renderRoot.querySelector('button.toggle-menu') as HTMLElement;
+        const toggleButton = this.renderRoot.querySelector(
+          'button.toggle-menu',
+        ) as HTMLElement;
         toggleButton?.focus();
       });
     }
@@ -292,7 +298,10 @@ export class ItemNavigator
         title="Toggle theater side panels"
         aria-label="Toggle theater side panels"
       >
-        <ia-icon-ellipses aria-hidden="true" role="presentation"></ia-icon-ellipses>
+        <ia-icon-ellipses
+          aria-hidden="true"
+          role="presentation"
+        ></ia-icon-ellipses>
       </button>
     `;
   }
@@ -304,10 +313,10 @@ export class ItemNavigator
   get renderSideMenu(): TemplateResult {
     return html`
       <nav>
-        <div class="minimized ${classMap({hidden: this.menuOpened})}">
+        <div class="minimized ${classMap({ hidden: this.menuOpened })}">
           ${this.shortcuts} ${this.menuToggleButton}
         </div>
-        <div id="menu" class=${classMap({hidden: !this.menuOpened})}>
+        <div id="menu" class=${classMap({ hidden: !this.menuOpened })}>
           <ia-menu-slider
             .menus=${this.menuContents}
             .selectedMenu=${this.selectedMenuId}

--- a/src/interfaces/menu-interfaces.ts
+++ b/src/interfaces/menu-interfaces.ts
@@ -5,25 +5,20 @@ export type MenuId = string;
 export interface MenuShortcutInterface {
   icon: TemplateResult;
   id: MenuId;
+  label: string;
 }
 
 export interface MenuDetailsInterface extends MenuShortcutInterface {
-  label: string;
   menuDetails?: TemplateResult;
   selected?: boolean;
   followable?: boolean;
   href?: string;
 }
 
-export interface MenuProviderBaseConfigInterface {
+export interface MenuProviderInterface extends MenuDetailsInterface {
   item: MetadataResponse;
   baseHost: string;
   subPrefix: string;
   updated?: any;
-}
-export interface MenuProviderInterface
-  extends MenuProviderBaseConfigInterface,
-    MenuDetailsInterface,
-    MenuShortcutInterface {
   actionButton: TemplateResult;
 }

--- a/src/interfaces/menu-interfaces.ts
+++ b/src/interfaces/menu-interfaces.ts
@@ -13,6 +13,7 @@ export interface MenuDetailsInterface extends MenuShortcutInterface {
   selected?: boolean;
   followable?: boolean;
   href?: string;
+  component?: TemplateResult;
 }
 
 export interface MenuProviderInterface extends MenuDetailsInterface {
@@ -20,5 +21,5 @@ export interface MenuProviderInterface extends MenuDetailsInterface {
   baseHost: string;
   subPrefix: string;
   updated?: any;
-  actionButton: TemplateResult;
+  actionButton?: TemplateResult;
 }

--- a/src/menu-slider/ia-menu-slider.ts
+++ b/src/menu-slider/ia-menu-slider.ts
@@ -1,5 +1,5 @@
 import { LitElement, html, nothing } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, query } from 'lit/decorators.js';
 import menuSliderCSS from './styles/menu-slider';
 import '@internetarchive/icon-collapse-sidebar';
 import './menu-button';
@@ -27,14 +27,8 @@ export class IaMenuSlider extends LitElement {
 
   @property({ type: Boolean }) animateMenuOpen = false;
 
-  updated() {
-    const { actionButton } =
-      this.selectedMenuDetails || ({} as Record<string, any>);
-    const actionButtonHasChanged = actionButton !== this.selectedMenuAction;
-    if (actionButtonHasChanged) {
-      this.selectedMenuAction = actionButton || nothing;
-    }
-  }
+  @query('.content.open button.close') contentCloseButton!: HTMLElement;
+
 
   /**
    * Event handler, captures state of selected menu
@@ -45,6 +39,9 @@ export class IaMenuSlider extends LitElement {
     const { actionButton } =
       this.selectedMenuDetails || ({} as Record<string, any>);
     this.selectedMenuAction = actionButton || nothing;
+    this.updateComplete.then(() => {
+      this.contentCloseButton?.focus();
+    });
   }
 
   /**

--- a/src/menu-slider/ia-menu-slider.ts
+++ b/src/menu-slider/ia-menu-slider.ts
@@ -151,6 +151,7 @@ export class IaMenuSlider extends LitElement {
         <button
           class="close"
           aria-label="Close this menu"
+          title="Close this menu"
           @click=${this.closePanel}
         >
           <ia-icon-collapse-sidebar></ia-icon-collapse-sidebar>
@@ -164,6 +165,7 @@ export class IaMenuSlider extends LitElement {
       <button
         class="close"
         aria-label="Close this menu"
+        title="Close this menu"
         @click=${this.closeMenu}
       >
         <ia-icon-collapse-sidebar></ia-icon-collapse-sidebar>

--- a/src/menu-slider/ia-menu-slider.ts
+++ b/src/menu-slider/ia-menu-slider.ts
@@ -29,6 +29,7 @@ export class IaMenuSlider extends LitElement {
 
   @query('.content.open button.close') contentCloseButton!: HTMLElement;
 
+  @query('.menu-list') menuList!: HTMLUListElement;
 
   /**
    * Event handler, captures state of selected menu
@@ -56,6 +57,39 @@ export class IaMenuSlider extends LitElement {
       detail: this.selectedMenuDetails,
     });
     this.dispatchEvent(drawerClosed);
+  }
+
+  closePanel() {
+    const menuId = this.selectedMenu;
+    this.selectedMenu = '';
+    this.selectedMenuAction = nothing;
+
+    // Return focus to the menu button that was previously selected
+    if (menuId) {
+      this.updateComplete.then(() => {
+        const menuIndex = this.menus.findIndex(menu => menu.id === menuId);
+        if (menuIndex !== -1) {
+          const menuButton = this.menuList.querySelector(
+            `li:nth-child(${menuIndex + 1}) menu-button`,
+          ) as HTMLElement;
+          menuButton?.focus();
+        }
+      });
+    }
+  }
+
+  /**
+   * Handle keyboard events, specifically ESC key to close menu details
+   */
+  handleKeyDown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      if (this.selectedMenu) {
+        this.closePanel();
+      } else {
+        this.closeMenu();
+      }
+    }
   }
 
   get selectedMenuDetails() {
@@ -116,7 +150,14 @@ export class IaMenuSlider extends LitElement {
           <h3>${label}</h3>
           <span class="extra-details">${menuDetails}</span>
         </div>
-        ${actionBlock} ${this.closeButton}
+        ${actionBlock}
+        <button
+          class="close"
+          aria-label="Close this menu"
+          @click=${this.closePanel}
+        >
+          <ia-icon-collapse-sidebar></ia-icon-collapse-sidebar>
+        </button>
       </header>
     `;
   }
@@ -136,7 +177,7 @@ export class IaMenuSlider extends LitElement {
   /** @inheritdoc */
   render() {
     return html`
-      <div class="main">
+      <div class="main" @keydown=${this.handleKeyDown}>
         <div class="menu ${this.sliderDetailsClass}">
           ${this.closeButton}
           <ul class="menu-list">

--- a/src/menu-slider/menu-button.ts
+++ b/src/menu-slider/menu-button.ts
@@ -49,7 +49,12 @@ export class MenuButton extends LitElement {
 
   get menuItem() {
     return html`
-      <span class="icon ${this.iconClass}"> ${this.icon} </span>
+      <span
+        class="icon ${this.iconClass}"
+        aria-hidden="true"
+        role="presentation"
+        title="${this.label}"
+      >${this.icon}</span>
       <span class="label">${this.label}</span>
       <span class="menu-details">${this.menuDetails}</span>
     `;

--- a/src/menu-slider/menu-button.ts
+++ b/src/menu-slider/menu-button.ts
@@ -54,7 +54,8 @@ export class MenuButton extends LitElement {
         aria-hidden="true"
         role="presentation"
         title="${this.label}"
-      >${this.icon}</span>
+        >${this.icon}</span
+      >
       <span class="label">${this.label}</span>
       <span class="menu-details">${this.menuDetails}</span>
     `;

--- a/src/menu-slider/menu-button.ts
+++ b/src/menu-slider/menu-button.ts
@@ -13,13 +13,13 @@ export class MenuButton extends LitElement {
     delegatesFocus: true,
   };
 
-  @property({ type: String }) icon: TemplateResult | string = '';
+  @property({ type: Object }) icon: TemplateResult | string = '';
 
   @property({ type: String }) href = '';
 
   @property({ type: String }) label = '';
 
-  @property({ type: String }) menuDetails: TemplateResult | string = '';
+  @property({ type: Object }) menuDetails: TemplateResult | string = '';
 
   @property({ type: String }) buttonId = '';
 
@@ -57,7 +57,6 @@ export class MenuButton extends LitElement {
       <span
         class="icon ${this.iconClass}"
         aria-hidden="true"
-        role="presentation"
         title="${this.label}"
         >${this.icon}</span
       >

--- a/src/menu-slider/menu-button.ts
+++ b/src/menu-slider/menu-button.ts
@@ -1,4 +1,4 @@
-import { html, LitElement } from 'lit';
+import { html, LitElement, TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import menuButtonCSS from './styles/menu-button';
 
@@ -13,13 +13,13 @@ export class MenuButton extends LitElement {
     delegatesFocus: true,
   };
 
-  @property({ type: String }) icon = '';
+  @property({ type: String }) icon: TemplateResult | string = '';
 
   @property({ type: String }) href = '';
 
   @property({ type: String }) label = '';
 
-  @property({ type: String }) menuDetails = '';
+  @property({ type: String }) menuDetails: TemplateResult | string = '';
 
   @property({ type: String }) buttonId = '';
 

--- a/src/menu-slider/menu-button.ts
+++ b/src/menu-slider/menu-button.ts
@@ -8,6 +8,11 @@ export class MenuButton extends LitElement {
     return menuButtonCSS;
   }
 
+  static shadowRootOptions = {
+    ...LitElement.shadowRootOptions,
+    delegatesFocus: true,
+  };
+
   @property({ type: String }) icon = '';
 
   @property({ type: String }) href = '';

--- a/src/menu-slider/styles/menu-button.ts
+++ b/src/menu-slider/styles/menu-button.ts
@@ -6,6 +6,11 @@ export default css`
     text-decoration: none;
   }
 
+  button.menu-item {
+    -webkit-appearance: none;
+    appearance: none;
+  }
+
   .menu-item {
     display: inline-flex;
     width: 100%;
@@ -18,12 +23,12 @@ export default css`
     align-items: center;
     border: none;
     cursor: pointer;
+    transition: background-color 0.2s;
+    border-radius: 6px;
   }
 
-  button.menu-item {
-    -webkit-appearance: none;
-    appearance: none;
-    border-radius: 0;
+  .menu-item:hover {
+    background-color: rgba(255,255,255,0.1);
   }
 
   .label {
@@ -58,6 +63,11 @@ export default css`
     -webkit-box-pack: center;
     -ms-flex-pack: center;
     justify-content: center;
+  }
+
+  .menu-item > .icon > * {
+    /* Prevent tooltip containing icon literal description */
+    pointer-events: none;
   }
 
   .menu-item.selected .icon {

--- a/src/menu-slider/styles/menu-button.ts
+++ b/src/menu-slider/styles/menu-button.ts
@@ -28,7 +28,7 @@ export default css`
   }
 
   .menu-item:hover {
-    background-color: rgba(255,255,255,0.1);
+    background-color: rgba(255, 255, 255, 0.1);
   }
 
   .label {

--- a/src/menu-slider/styles/menu-slider.ts
+++ b/src/menu-slider/styles/menu-slider.ts
@@ -29,10 +29,6 @@ export default css`
     transform: translateX(calc(${sliderWidth} * -1));
   }
 
-  .menu > button.close {
-    right: 0.7rem;
-  }
-
   button {
     cursor: pointer;
   }
@@ -72,11 +68,13 @@ export default css`
     position: absolute;
   }
   button.close {
-    right: 0.5rem;
-  }
-
-  button.close * {
-    float: right;
+    min-width: 38px;
+    min-height: 38px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    right: 0;
+    top: 0;
   }
 
   .content {

--- a/src/menus/share-panel.ts
+++ b/src/menus/share-panel.ts
@@ -151,7 +151,7 @@ export class IauxSharingOptions extends LitElement {
   render() {
     return html`
       ${this.header}
-      <main>
+      <div>
         ${this.sharingOptions.map(
           option =>
             html` <a class="share-option" href="${option.url}" target="_blank">
@@ -185,7 +185,7 @@ export class IauxSharingOptions extends LitElement {
             </p>
           </div>
         </details>
-      </main>
+      </div>
     `;
   }
 
@@ -220,7 +220,7 @@ export class IauxSharingOptions extends LitElement {
         font-size: 1.4rem;
       }
 
-      main {
+      :host > div {
         padding: 1rem 0;
       }
 

--- a/src/menus/share-panel.ts
+++ b/src/menus/share-panel.ts
@@ -81,7 +81,7 @@ export class IauxSharingOptions extends LitElement {
     this.sharingOptions = [
       {
         name: 'Twitter',
-        icon: html`<ia-icon-twitter></ia-icon-twitter>`,
+        icon: html`<ia-icon-twitter aria-hidden="true"></ia-icon-twitter>`,
         url: `https://twitter.com/intent/tweet?${new URLSearchParams({
           url: shareUrl,
           text: shareBlurb,
@@ -90,14 +90,14 @@ export class IauxSharingOptions extends LitElement {
       },
       {
         name: 'Facebook',
-        icon: html`<ia-icon-facebook></ia-icon-facebook>`,
+        icon: html`<ia-icon-facebook aria-hidden="true"></ia-icon-facebook>`,
         url: `https://www.facebook.com/sharer/sharer.php?${new URLSearchParams({
           u: shareUrl,
         })}`,
       },
       {
         name: 'Tumblr',
-        icon: html`<ia-icon-tumblr></ia-icon-tumblr>`,
+        icon: html`<ia-icon-tumblr aria-hidden="true"></ia-icon-tumblr>`,
         url: `https://www.tumblr.com/widgets/share/tool/preview?${new URLSearchParams(
           {
             posttype: 'link',
@@ -108,7 +108,7 @@ export class IauxSharingOptions extends LitElement {
       },
       {
         name: 'Pinterest',
-        icon: html`<ia-icon-pinterest></ia-icon-pinterest>`,
+        icon: html`<ia-icon-pinterest aria-hidden="true"></ia-icon-pinterest>`,
         url: `http://www.pinterest.com/pin/create/button/?${new URLSearchParams(
           {
             url: shareUrl,
@@ -118,7 +118,7 @@ export class IauxSharingOptions extends LitElement {
       },
       {
         name: 'Email',
-        icon: html`<ia-icon-email></ia-icon-email>`,
+        icon: html`<ia-icon-email aria-hidden="true"></ia-icon-email>`,
         url: `mailto:?${new URLSearchParams({
           subject: shareBlurb,
           body: shareUrl,
@@ -160,7 +160,7 @@ export class IauxSharingOptions extends LitElement {
         )}
         <details>
           <summary class="share-option">
-            <ia-icon-link></ia-icon-link>
+            <ia-icon-link aria-hidden="true"></ia-icon-link>
             Get an embeddable link
           </summary>
           <div class="embed">
@@ -231,6 +231,12 @@ export class IauxSharingOptions extends LitElement {
         text-decoration: none;
         color: var(--shareLinkColor);
         cursor: pointer;
+        transition: background-color 0.2s;
+        border-radius: 6px;
+      }
+
+      .share-option:hover {
+        background-color: rgba(255, 255, 255, 0.05);
       }
 
       .share-option > * {

--- a/test/iaux-item-navigator.test.ts
+++ b/test/iaux-item-navigator.test.ts
@@ -343,6 +343,7 @@ describe('ItemNavigator', () => {
       const anotherShortcut = {
         id: 'foo',
         icon: html`<i class="foo-shortcut"></i>`,
+        label: 'Foo',
       };
       el.menuContents = [menuProvider];
       el.menuShortcuts = [shortcut, anotherShortcut];


### PR DESCRIPTION
Sister PR: https://github.com/internetarchive/bookreader/pull/1464

Fixes:

* Icons are now no longer read out when not needed
* Pressing "space" or "enter" with a screenreader lets you click on a shortcut or slider-menu button
* Opening/closing the sidebar logically move focus into the sidebar
* The shortcuts are no longer focussible when the sidebar is opened
* The ESC key correctly closes a panel or the entire sidebar if no panel is open
* The close button would previously always entirely close the sidebar, even if a panel was open. Now it closes the panel and takes you back to the main menu, and you have to click the close button a second time to fully close the menu. Not sure if this is ideal, but it makes a bit more sense from a keyboard navigation perspective.
* Added hover effects for when hovering over clickable things.

Other changes:

* Was hitting some typing errors, so tightened/cleaned up a few of the types around the codebase

https://github.com/user-attachments/assets/4652b160-7c7f-4ba3-9641-2277bedecd6c


