### PR TITLE
Add aria-expanded to BR sidebar menus

### DIFF
--- a/src/iaux-item-navigator.ts
+++ b/src/iaux-item-navigator.ts
@@ -345,6 +345,7 @@ export class ItemNavigator
           @click="${() => this.openShortcut(id)}"
           title=${label}
           aria-label=${label}
+          aria-expanded="false"
         >
           ${icon}
         </button>

--- a/src/iaux-item-navigator.ts
+++ b/src/iaux-item-navigator.ts
@@ -294,8 +294,9 @@ export class ItemNavigator
       <button
         class="toggle-menu"
         @click=${this.toggleMenu}
-        title="Toggle theater side panels"
-        aria-label="Toggle theater side panels"
+        title="Open side panel"
+        aria-label="Open side panel"
+        aria-expanded="false"
       >
         <ia-icon-ellipses aria-hidden="true"></ia-icon-ellipses>
       </button>

--- a/src/menu-slider/menu-button.ts
+++ b/src/menu-slider/menu-button.ts
@@ -44,10 +44,6 @@ export class MenuButton extends LitElement {
     );
   }
 
-  get buttonClass() {
-    return this.selected ? 'selected' : '';
-  }
-
   get iconClass() {
     return this.selected ? 'active' : '';
   }
@@ -69,7 +65,8 @@ export class MenuButton extends LitElement {
     return html`
       <a
         href="${this.href}"
-        class="menu-item ${this.buttonClass}"
+        class="menu-item"
+        aria-expanded="${this.selected}"
         @click=${this.followable ? undefined : this.onClick}
         >${this.menuItem}</a
       >
@@ -78,7 +75,11 @@ export class MenuButton extends LitElement {
 
   get clickButton() {
     return html`
-      <button class="menu-item ${this.buttonClass}" @click=${this.onClick}>
+      <button
+        class="menu-item"
+        aria-expanded="${this.selected}"
+        @click=${this.onClick}
+      >
         ${this.menuItem}
       </button>
     `;

--- a/src/menu-slider/styles/menu-button.ts
+++ b/src/menu-slider/styles/menu-button.ts
@@ -70,7 +70,7 @@ export default css`
     pointer-events: none;
   }
 
-  .menu-item.selected .icon {
+  .menu-item[aria-expanded='true'] .icon {
     background-color: var(--activeButtonBg);
     border-radius: 1rem 0 0 1rem;
   }


### PR DESCRIPTION
Addresses this point in the a11y audit:


"On activating image buttons such as ""Search for something"", ""Bookmarks (0)"", ""Downloadable files (2 formats)"", ""Visual Adjustments"" and ""Share this book"" present in the ""Bookreader Item Preview"" section, the content dynamically gets expanded and collapsed below. The dynamically updating button's state is not defined programmatically.
As a result, screen reader users are not able to understand the image button's functionality.

Similar instance is found for following pages:
• The formation of the North Carolina Counties
• The North Carolina Historical Review
• Proceedings - Royal Commission on matters of health and safety arising from the use of asbestos in Ontario
• WHAT IS THE CITIZENS' INQUIRY BRANCH? – PAMPHLET
• Report on provincial library service in Ontario
• Audio page 

Code Snippet:
<button class=""menu-item "">
<span class=""icon ""> 
<icon-bookmark state=""hollow"" style=""--iconWidth: 16px; --iconHeight: 24px;""></icon-bookmark> </span>
<span class=""label"">Bookmarks</span>
(...)
</button>"

Set 'aria-expanded' attribute to 'false' for the image button by default as the image button is in the collapsed state. Ensure that the value of 'aria-expanded' attribute changes to 'true' in expanded state on user interaction via scripting.