### PR TITLE
WEBDEV-8764: Export menu interfaces from the package root

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,3 +7,11 @@ export { IauxSharingOptions, iauxShareIcon } from './src/menus/share-panel';
 export { viewableFilesIcon } from './src/menus/viewable-files';
 export { IauxViewableFiles } from './src/menus/viewable-files';
 export { IauxSortFilesButton } from './src/menus/viewable-files';
+
+// menu interfaces
+export type {
+  MenuId,
+  MenuShortcutInterface,
+  MenuDetailsInterface,
+  MenuProviderInterface,
+} from './src/interfaces/menu-interfaces';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/ia-item-navigator",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/ia-item-navigator",
-      "version": "2.2.3",
+      "version": "2.2.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/icon-collapse-sidebar": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-item-navigator",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Internet Archive's Item Navigator, visually explore an item's contents.",
   "repository": {
     "type": "git",

--- a/src/iaux-item-navigator.ts
+++ b/src/iaux-item-navigator.ts
@@ -310,7 +310,10 @@ export class ItemNavigator
   get renderSideMenu(): TemplateResult {
     return html`
       <nav>
-        <div class="minimized ${classMap({ hidden: this.menuOpened })}" part="minimized-menu">
+        <div
+          class="minimized ${classMap({ hidden: this.menuOpened })}"
+          part="minimized-menu"
+        >
           ${this.shortcuts} ${this.menuToggleButton}
         </div>
         <div id="menu" class=${classMap({ hidden: !this.menuOpened })}>


### PR DESCRIPTION
Re-export the menu interface types (`MenuId`, `MenuShortcutInterface`, `MenuDetailsInterface`, `MenuProviderInterface`) from the root `index.ts` so consumers get the menu-content contract from the package root instead of importing from `dist/src/interfaces/menu-interfaces` directly.

Type-only, no runtime change. Bumps 2.2.3 to 2.2.4.

Unblocks the offshoot theater-player decoupling (WEBDEV-8762): its pdf-theater currently deep-imports `MenuProviderInterface`. Verified `tsc` emits the re-export into `dist/index.d.ts`, and offshoot typechecks importing it from the root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
